### PR TITLE
[deps] Add and import Buffer, to avoid relying on a global definition.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,8 +1199,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1464,7 +1463,6 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
       "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -3659,8 +3657,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "repository": "charpeni/whatwg-url",
   "dependencies": {
+    "buffer": "^5.4.3",
     "webidl-conversions": "^5.0.0"
   },
   "devDependencies": {

--- a/src/url-state-machine.js
+++ b/src/url-state-machine.js
@@ -1,4 +1,5 @@
 "use strict";
+const { Buffer } = require("buffer/");
 const punycode = require("punycode");
 
 const infra = require("./infra");

--- a/src/urlencoded.js
+++ b/src/urlencoded.js
@@ -1,4 +1,6 @@
 "use strict";
+const { Buffer } = require("buffer/");
+
 const { isASCIIHex } = require("./infra");
 
 function p(char) {


### PR DESCRIPTION
Hi! It's me, from https://github.com/charpeni/react-native-url-polyfill/issues/154.

We found what seems like a good way to use your work adapting `whatwg-url`, even as we're stuck, for the time being, on React Native v0.59.10! (Meaning that we can't use `react-native-url-polyfill` for now.)

Much of the work in `react-native-url-polyfill`, it seems, is done in this package, and using this package directly seems possible with our version of React Native. (As long as we don't polyfill it as the global `URL` object, I think; React Native likely depends on an implementation of `createObjectURL`.)

Since this package has already been adapted somewhat for use in React Native, by making it lighter with the removal of Unicode support, what do you think of also having it declare [`buffer`](chat.zulip.org) as a dependency and importing it where needed, rather than expecting something to be defined at the Buffer global variable? It's fine if not, I just thought I'd ask. Feel free to make adjustments as needed, or to close.