### PR TITLE
Add punycode as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "whatwg-url-without-unicode",
-  "version": "8.0.0-1",
+  "version": "8.0.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5602,8 +5602,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "repository": "charpeni/whatwg-url",
   "dependencies": {
     "buffer": "^5.4.3",
+    "punycode": "^2.1.1",
     "webidl-conversions": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixing https://github.com/charpeni/react-native-url-polyfill/issues/140.